### PR TITLE
Upgrade hashicorp/setup-terraform to v2 for node 16

### DIFF
--- a/.github/workflows/abbey-grant-kit-generate-policy-input.yaml
+++ b/.github/workflows/abbey-grant-kit-generate-policy-input.yaml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Setup Terraform
         id: setup
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
 

--- a/.github/workflows/abbey-grant-kit-materialize.yaml
+++ b/.github/workflows/abbey-grant-kit-materialize.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
 


### PR DESCRIPTION
## What
Upgrade the `hashicorp/setup-terraform' github actions step to use v2
* https://github.com/hashicorp/setup-terraform

## Why
Node 12 is being deprecated so this is causing a warning in the Actions run page

## Testing
Did a workflow run with the v2 action step on my own repo: https://github.com/hatim-khan/abbey-starter-kit-gcp-groups/actions/runs/5967059988/job/16187943696

```
  - name: Setup Terraform
        id: setup
        uses: hashicorp/setup-terraform@v2
        with:
          terraform_wrapper: false
```

<img width="1254" alt="image" src="https://github.com/abbeylabs/abbey-starter-kit-quickstart/assets/8519403/4519ce17-0eb1-49f2-844e-7ff585849f79">
