### PR TITLE
Use local variables in main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,10 +16,10 @@ terraform {
 }
 
 locals {
-  username = "" #CHANGEME
+  account_name = "" #CHANGEME
   repo_name = "" #CHANGEME
 
-  repo = "github://${local.username}/${local.repo_name}"
+  repo = "github://${local.account_name}/${local.repo_name}"
   location = "${local.repo}/access.tf"
   policies = "${local.repo}/policies"
 

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ locals {
   repo_name = "" #CHANGEME
 
   repo = "github://${local.account_name}/${local.repo_name}"
-  location = "${local.repo}/access.tf"
+  output_location = "${local.repo}/access.tf"
   policies = "${local.repo}/policies"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ resource "abbey_grant_kit" "abbey_demo_site" {
   ]
 
   output = {
-    location = local.ouput_location
+    location = local.output_location
     append = <<-EOT
       resource "abbey_demo" "grant_read_write_access" {
         permission = "read_write"

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,19 @@ terraform {
   }
 }
 
+locals {
+  username = "" #CHANGEME
+  repo_name = "" #CHANGEME
+
+  repo = "github://${local.username}/${local.repo_name}"
+  location = "${local.repo}/access.tf"
+  policies = "${local.repo}/policies"
+
+  reviewers = [
+    "alice@example.com", #CHANGEME
+  ]
+}
+
 provider "abbey" {
   # Configuration options
   bearer_auth = var.abbey_token
@@ -30,20 +43,18 @@ resource "abbey_grant_kit" "abbey_demo_site" {
     steps = [
       {
         reviewers = {
-          one_of = ["replace-me@example.com"] # CHANGEME
+          one_of = local.reviewers
         }
       }
     ]
   }
 
   policies = [
-    { bundle = "github://replace-me-with-organization/replace-me-with-repo/policies" } # CHANGEME
+    { bundle = local.policies } # CHANGEME
   ]
 
   output = {
-    # Replace with your own path pointing to where you want your access changes to manifest.
-    # Path is an RFC 3986 URI, such as `github://{organization}/{repo}/path/to/file.tf`.
-    location = "github://replace-me-with-organization/replace-me-with-repo/access.tf" # CHANGEME
+    location = local.ouput_location
     append = <<-EOT
       resource "abbey_demo" "grant_read_write_access" {
         permission = "read_write"

--- a/main.tf
+++ b/main.tf
@@ -22,10 +22,6 @@ locals {
   repo = "github://${local.account_name}/${local.repo_name}"
   location = "${local.repo}/access.tf"
   policies = "${local.repo}/policies"
-
-  reviewers = [
-    "alice@example.com", #CHANGEME
-  ]
 }
 
 provider "abbey" {
@@ -43,7 +39,7 @@ resource "abbey_grant_kit" "abbey_demo_site" {
     steps = [
       {
         reviewers = {
-          one_of = local.reviewers
+          one_of = ["alice@example.com"] #CHANGEME
         }
       }
     ]


### PR DESCRIPTION
## What
* Use local vars for github name & repo
* Only will merge this repo in addition with doc changes - reworking the quickstart as part of another task so will merge this once we publish the new quickstart guide

## Why
* Make it easier for users to update variables in a single block rather than editing sections in and out of the grant kit terraform

https://linear.app/abbey-labs/issue/ABB-1067/use-local-vars-in-quickstart

## Checklist & Testing
*Does this change require any testing?*
An example of some testing to do:
- [x] : use local vars format in a deployed grant kit to ensure variables are interpolated correctly

Tested in my abbey bestpizza org
![image](https://github.com/abbeylabs/abbey-starter-kit-quickstart/assets/8519403/9f309856-99fd-4d0a-8a81-d809a443ef78)

```
locals {
  account_name = "hatim-khan"
  repo_name = "abbey-starter-kit-quickstart"

  repo = "github://${local.account_name}/${local.repo_name}"
  output_location = "${local.repo}/access.tf"
  policies = "${local.repo}/policies"
}

provider "abbey" {
  # Configuration options
  bearer_auth = var.abbey_token
}


resource "abbey_grant_kit" "abbey_gk_local_vars" {
  name = "abbey_gk_local_vars"
  description = <<-EOT
    Grants access to Abbey's Demo Page using local variables.
  EOT

  workflow = {
    steps = [
      {
        reviewers = {
          one_of = ["hat@abbey.io"]
        }
      }
    ]
  }

  policies = [
    { bundle = local.policies } # CHANGEME
  ]

  output = {
    location = local.output_location
    append = <<-EOT
      resource "abbey_demo" "grant_read_write_access_local_vars" {
        permission = "read_write"
        email = "{{ .data.system.abbey.identities.abbey.email }}"
      }
    EOT
  }
}
```

## Deploy Steps
*Does this change require any special deploy steps?*
- [ ] : merge in this PR
- [ ] : update quickstart docs

