### PR TITLE
Update policy to grant access for 6 hours instead of 0 minutes

### DIFF
--- a/policies/common/common.rego
+++ b/policies/common/common.rego
@@ -3,6 +3,6 @@ package common
 import data.abbey.functions
 
 allow[msg] {
-    functions.expire_after("0m")
-    msg := "granting access for 0 minutes"
+    functions.expire_after("6h")
+    msg := "granting access for 6 hours"
 }


### PR DESCRIPTION
## What
Update the policy used by grant kits to expire access after 6 hours instead of 0 minutes

## Why
Setting to 0 minutes as default is confusing/unrealistic, so change it to 6 hours instead